### PR TITLE
Make type inference work

### DIFF
--- a/src/array/iter/mod.rs
+++ b/src/array/iter/mod.rs
@@ -171,7 +171,7 @@ mod tests {
     use crate::{
         s,
         storage::{Storage, StorageImpl},
-        Array, NDArray, NDArrayMut, NDArrayOwned, NDims, Result,
+        Array, NDArray, NDArrayMut, NDArrayOwned, Result,
     };
 
     macro_rules! test_iterator_of_1d_array {
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn iterate_empty_array() {
-        let a = Array::<StorageImpl<Vec<u64>>, NDims<3>>::zeros(&[1_usize, 0, 3]);
+        let a = Array::<StorageImpl<Vec<u64>>, _>::zeros(&[1_usize, 0, 3]);
 
         assert!(a.iter().next().is_none());
     }

--- a/src/array/linarg.rs
+++ b/src/array/linarg.rs
@@ -2,12 +2,14 @@ use core::ops::{AddAssign, Mul};
 
 use crate::{
     storage::Storage, Array, Dimensionality, DimensionalityAfterDot, Dot, NDArray, NDArrayMut,
-    NDArrayOwned, Order,
+    NDArrayOwned, Order, Shape,
 };
 
 impl<'a, 'b, D, D1, O, S, S1> Dot<'a, &'b Array<S1, D1, O>> for Array<S, D, O>
 where
     D: Dimensionality + DimensionalityAfterDot<D1>,
+    <<D as DimensionalityAfterDot<D1>>::Output as Dimensionality>::Shape:
+        Shape<Dimensionality = <D as DimensionalityAfterDot<D1>>::Output>,
     D1: Dimensionality,
     O: Order,
     S: Storage,
@@ -77,7 +79,7 @@ mod tests {
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
-    use crate::{s, storage::StorageImpl, Array, Dot, NDArray, NDArrayOwned, NDims};
+    use crate::{s, storage::StorageImpl, Array, Dot, NDArray, NDArrayOwned};
 
     #[test]
     fn dot_2d() {
@@ -132,7 +134,7 @@ mod tests {
 
     #[test]
     fn dot_of_zeros() {
-        let a = Array::<StorageImpl<Vec<usize>>, NDims<_>>::zeros(&[3, 3]);
+        let a = Array::<StorageImpl<Vec<usize>>, _>::zeros(&[3, 3]);
 
         assert!(a.dot(&a).iter().all(|&x| x == 0));
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -427,7 +427,7 @@ where
         let mut out_shape =
             <<NS as NewShape>::Dimensionality as Dimensionality>::shape_zeroed(shape.n_dims());
         for (dest, src) in out_shape.as_mut().iter_mut().zip(self.shape.as_ref()) {
-            *dest = *src as usize;
+            *dest = *src;
         }
         out_shape
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -313,11 +313,14 @@ where
     O: Order,
     S: StorageOwned,
 {
-    fn allocate_uninitialized(shape: &<D as Dimensionality>::Shape) -> Self {
+    fn allocate_uninitialized<Sh>(shape: &Sh) -> Self
+    where
+        Sh: Shape<Dimensionality = D>,
+    {
         Array {
-            shape: shape.clone(),
-            strides: shape.to_default_strides::<O>(),
-            storage: S::allocate_uninitialized(shape.array_len()),
+            shape: shape.as_associated_shape().clone(),
+            strides: shape.as_associated_shape().to_default_strides::<O>(),
+            storage: S::allocate_uninitialized(shape.as_associated_shape().array_len()),
             offset: 0,
             phantom: PhantomData,
         }
@@ -377,27 +380,29 @@ where
         }
     }
 
-    fn ones(shape: &<D as Dimensionality>::Shape) -> Self
+    fn ones<Sh>(shape: &Sh) -> Self
     where
         <S as Storage>::Elem: One,
+        Sh: Shape<Dimensionality = D>,
     {
         Array {
-            shape: shape.clone(),
-            strides: shape.to_default_strides::<O>(),
-            storage: S::ones(shape.array_len()),
+            shape: shape.as_associated_shape().clone(),
+            strides: shape.as_associated_shape().to_default_strides::<O>(),
+            storage: S::ones(shape.as_associated_shape().array_len()),
             offset: 0,
             phantom: PhantomData,
         }
     }
 
-    fn zeros(shape: &<D as Dimensionality>::Shape) -> Self
+    fn zeros<Sh>(shape: &Sh) -> Self
     where
         <S as Storage>::Elem: Zero,
+        Sh: Shape<Dimensionality = D>,
     {
         Array {
-            shape: shape.clone(),
-            strides: shape.to_default_strides::<O>(),
-            storage: S::zeros(shape.array_len()),
+            shape: shape.as_associated_shape().clone(),
+            strides: shape.as_associated_shape().to_default_strides::<O>(),
+            storage: S::zeros(shape.as_associated_shape().array_len()),
             offset: 0,
             phantom: PhantomData,
         }
@@ -687,7 +692,7 @@ mod tests {
     #[test]
     fn allocate_uninitialized() {
         let shape = [2, 3, 4];
-        let a3 = Array::<StorageImpl<Vec<f64>>, NDims<3>>::allocate_uninitialized(&shape);
+        let a3 = Array::<StorageImpl<Vec<f64>>, _>::allocate_uninitialized(&shape);
 
         assert_eq!(a3.shape(), &shape);
     }
@@ -931,7 +936,7 @@ mod tests {
     #[test]
     fn ones() {
         let shape = [2, 3, 4];
-        let a3 = Array::<StorageImpl<Vec<u64>>, NDims<3>>::ones(&shape);
+        let a3 = Array::<StorageImpl<Vec<u64>>, _>::ones(&shape);
 
         assert_eq!(a3.shape(), &shape);
         assert!(a3.iter().all(|&x| x == 1));
@@ -1103,7 +1108,7 @@ mod tests {
     #[test]
     fn zeros() {
         let shape = [2, 3, 4];
-        let a3 = Array::<StorageImpl<Vec<u64>>, NDims<3>>::zeros(&shape);
+        let a3 = Array::<StorageImpl<Vec<u64>>, _>::zeros(&shape);
 
         assert_eq!(a3.shape(), &shape);
         assert!(a3.iter().all(|&x| x == 0));

--- a/src/array/ops.rs
+++ b/src/array/ops.rs
@@ -61,6 +61,7 @@ macro_rules! impl_unary_op {
         impl<D, O, S> $trait for &Array<S, D, O>
         where
             D: Dimensionality,
+            <D as Dimensionality>::Shape: Shape<Dimensionality = D>,
             O: Order,
             S: Storage,
             <S as Storage>::Elem: $trait<Output = <S as Storage>::Elem>,
@@ -102,6 +103,8 @@ macro_rules! impl_binary_op {
         impl<D, D1, O, S, S1> $trait<Array<S1, D1, O>> for Array<S, D, O>
         where
             D: Dimensionality + DimensionalityMax<D1>,
+            <<D as DimensionalityMax<D1>>::Output as Dimensionality>::Shape:
+                Shape<Dimensionality = <D as DimensionalityMax<D1>>::Output>,
             D1: Dimensionality,
             O: Order,
             S: StorageMut + StorageOwned,
@@ -118,6 +121,8 @@ macro_rules! impl_binary_op {
         impl<D, D1, O, S, S1> $trait<&Array<S1, D1, O>> for Array<S, D, O>
         where
             D: Dimensionality + DimensionalityMax<D1>,
+            <<D as DimensionalityMax<D1>>::Output as Dimensionality>::Shape:
+                Shape<Dimensionality = <D as DimensionalityMax<D1>>::Output>,
             D1: Dimensionality,
             O: Order,
             S: StorageMut + StorageOwned,
@@ -169,6 +174,8 @@ macro_rules! impl_binary_op {
         where
             D: Dimensionality,
             D1: Dimensionality + DimensionalityMax<D>,
+            <<D1 as DimensionalityMax<D>>::Output as Dimensionality>::Shape:
+                Shape<Dimensionality = <D1 as DimensionalityMax<D>>::Output>,
             O: Order,
             S: Storage,
             <S as Storage>::Elem: $trait<<S1 as Storage>::Elem, Output = <S1 as Storage>::Elem>,
@@ -218,6 +225,8 @@ macro_rules! impl_binary_op {
         impl<D, D1, O, S, S1> $trait<&Array<S1, D1, O>> for &Array<S, D, O>
         where
             D: Dimensionality + DimensionalityMax<D1>,
+            <<D as DimensionalityMax<D1>>::Output as Dimensionality>::Shape:
+                Shape<Dimensionality = <D as DimensionalityMax<D1>>::Output>,
             D1: Dimensionality,
             O: Order,
             S: Storage,
@@ -272,6 +281,7 @@ macro_rules! impl_binary_op_with_scalar {
         impl<D, O, S, T> $trait<T> for &Array<S, D, O>
         where
             D: Dimensionality,
+            <D as Dimensionality>::Shape: Shape<Dimensionality = D>,
             O: Order,
             S: Storage,
             <S as Storage>::Elem: $trait<T, Output = <S as Storage>::Elem>,
@@ -322,6 +332,7 @@ macro_rules! impl_binary_op_for_scalar {
         impl<D, O, S> $trait<&Array<S, D, O>> for $scalar_type
         where
             D: Dimensionality,
+            <D as Dimensionality>::Shape: Shape<Dimensionality = D>,
             O: Order,
             S: Storage<Elem = $scalar_type>,
         {
@@ -408,6 +419,7 @@ macro_rules! impl_binary_op_for_scalar_wrapped {
         where
             Self: $trait<<S as Storage>::Elem, Output = <S as Storage>::Elem>,
             D: Dimensionality,
+            <D as Dimensionality>::Shape: Shape<Dimensionality = D>,
             O: Order,
             S: Storage,
             T: Copy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,9 @@ where
     O: Order,
     S: StorageOwned,
 {
-    fn allocate_uninitialized(shape: &<D as Dimensionality>::Shape) -> Self;
+    fn allocate_uninitialized<Sh>(shape: &Sh) -> Self
+    where
+        Sh: Shape<Dimensionality = D>;
     fn into_shape<NS>(self, shape: NS) -> Result<Array<S, <NS as NewShape>::Dimensionality, O>>
     where
         NS: NewShape;
@@ -142,10 +144,12 @@ where
     where
         NS: NewShape,
         NO: Order;
-    fn ones(shape: &<D as Dimensionality>::Shape) -> Self
+    fn ones<Sh>(shape: &Sh) -> Self
     where
-        <S as Storage>::Elem: One;
-    fn zeros(shape: &<D as Dimensionality>::Shape) -> Self
+        <S as Storage>::Elem: One,
+        Sh: Shape<Dimensionality = D>;
+    fn zeros<Sh>(shape: &Sh) -> Self
     where
-        <S as Storage>::Elem: Zero;
+        <S as Storage>::Elem: Zero,
+        Sh: Shape<Dimensionality = D>;
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -86,7 +86,7 @@ impl Order for RowMajor {
             .rev()
             .zip(strides[..len - 1].iter().rev())
         {
-            if stride != stride_expected as isize {
+            if stride != stride_expected {
                 return false;
             }
             stride_expected *= dim as isize;
@@ -151,7 +151,7 @@ impl Order for ColumnMajor {
 
         let mut stride_expected = shape[0] as isize * strides[0];
         for (&dim, &stride) in shape[1..].iter().zip(strides[1..].iter()) {
-            if stride != stride_expected as isize {
+            if stride != stride_expected {
                 return false;
             }
             stride_expected *= dim as isize;

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,9 +1,9 @@
 use crate::{Dimensionality, Shape};
 
 pub trait Order: 'static {
-    fn convert_shape_to_strides<S>(shape: &S, base_stride: isize, strides: &mut S::Strides)
+    fn convert_shape_to_strides<Sh>(shape: &Sh, base_stride: isize, strides: &mut Sh::Strides)
     where
-        S: Shape;
+        Sh: Shape;
     fn name<'a>() -> &'a str;
     fn is_data_contiguous<D>(
         shape: &<D as Dimensionality>::Shape,
@@ -13,11 +13,11 @@ pub trait Order: 'static {
         D: Dimensionality;
     fn is_data_aligned_monotonically(shape: &[usize], strides: &[isize]) -> bool;
 
-    fn convert_shape_to_default_strides<S>(shape: &S, strides: &mut S::Strides)
+    fn convert_shape_to_default_strides<Sh>(shape: &Sh, strides: &mut Sh::Strides)
     where
-        S: Shape,
+        Sh: Shape,
     {
-        Self::convert_shape_to_strides::<S>(shape, 1, strides)
+        Self::convert_shape_to_strides::<Sh>(shape, 1, strides)
     }
 }
 

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -9,7 +9,7 @@ use core::{
     ops::{Index, IndexMut},
 };
 
-use crate::Order;
+use crate::{Dimensionality, DynDim, NDims, Order};
 
 pub trait Shape:
     AsRef<[usize]>
@@ -22,6 +22,7 @@ pub trait Shape:
     + IndexMut<usize, Output = usize>
     + PartialEq
 {
+    type Dimensionality: Dimensionality;
     type Strides: AsRef<[isize]>
         + AsMut<[isize]>
         + Clone
@@ -32,6 +33,7 @@ pub trait Shape:
         + IndexMut<usize, Output = isize>
         + PartialEq;
     fn array_len(&self) -> usize;
+    fn as_associated_shape(&self) -> &<Self::Dimensionality as Dimensionality>::Shape;
     fn n_dims(&self) -> usize;
     fn to_default_strides<O>(&self) -> Self::Strides
     where
@@ -39,10 +41,15 @@ pub trait Shape:
 }
 
 impl<const N: usize> Shape for [usize; N] {
+    type Dimensionality = NDims<N>;
     type Strides = [isize; N];
 
     fn array_len(&self) -> usize {
         self.iter().product()
+    }
+
+    fn as_associated_shape(&self) -> &<Self::Dimensionality as Dimensionality>::Shape {
+        self
     }
 
     fn n_dims(&self) -> usize {
@@ -60,10 +67,15 @@ impl<const N: usize> Shape for [usize; N] {
 }
 
 impl Shape for Vec<usize> {
+    type Dimensionality = DynDim;
     type Strides = Vec<isize>;
 
     fn array_len(&self) -> usize {
         self.iter().product()
+    }
+
+    fn as_associated_shape(&self) -> &<Self::Dimensionality as Dimensionality>::Shape {
+        self
     }
 
     fn n_dims(&self) -> usize {


### PR DESCRIPTION
This change makes type inference work on `allocate_uninitialized`, `ones` and `zeros`.