### PR TITLE
Modify `Order` formatting

### DIFF
--- a/src/array/fmt.rs
+++ b/src/array/fmt.rs
@@ -1,4 +1,4 @@
-use core::{default::Default, fmt};
+use core::{any, default::Default, fmt};
 
 use super::ArrayBase;
 use crate::{dyn_s, storage::Storage, Dimensionality, NDArray, Order};
@@ -143,7 +143,7 @@ where
             ", shape={:?}, strides={:?}, order={}",
             self.shape,
             self.strides,
-            O::name(),
+            any::type_name::<O>().split("::").last().unwrap(),
         )?;
         Ok(())
     }

--- a/src/order.rs
+++ b/src/order.rs
@@ -11,7 +11,6 @@ pub trait Order: 'static {
     ) -> bool
     where
         D: Dimensionality;
-    fn name<'a>() -> &'a str;
 
     fn convert_shape_to_default_strides<Sh>(shape: &Sh, strides: &mut Sh::Strides)
     where
@@ -90,10 +89,6 @@ impl Order for RowMajor {
 
         true
     }
-
-    fn name<'a>() -> &'a str {
-        r#""row major""#
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -154,10 +149,6 @@ impl Order for ColumnMajor {
         }
 
         true
-    }
-
-    fn name<'a>() -> &'a str {
-        r#""column major""#
     }
 }
 


### PR DESCRIPTION
This change removes a method that are used only for formatting.