### PR TITLE
Remove specific types from traits

### DIFF
--- a/src/array/iter/sequence.rs
+++ b/src/array/iter/sequence.rs
@@ -1,7 +1,6 @@
 use core::{intrinsics, iter::FusedIterator, marker::PhantomData, mem, ptr::NonNull};
 
-use super::ArrayBase;
-use crate::{storage::Storage, Dimensionality, Shape};
+use crate::{storage::Storage, Dimensionality, NDArray, Shape};
 
 pub struct SequenceIter<'a, T: 'a, D>
 where
@@ -69,24 +68,24 @@ where
     D: Dimensionality,
 {
     #[inline]
-    pub fn new<O, S>(a: &ArrayBase<S, D, O>, axis: usize) -> Self
+    pub fn new<S>(a: &impl NDArray<D = D, S = S>, axis: usize) -> Self
     where
         D: Dimensionality,
         S: Storage<Elem = T>,
     {
-        let ptr = a.storage.as_ptr().wrapping_add(a.offset);
-        let len = a.shape.array_len() / a.shape[axis];
-        let mut shape = a.shape.clone();
+        let ptr = a.as_ptr();
+        let len = a.shape().array_len() / a.shape()[axis];
+        let mut shape = a.shape().clone();
         shape[axis] = 0;
 
         Self {
             ptr: unsafe { NonNull::new_unchecked(ptr as *mut T) },
-            indices: D::first_indices(&a.shape),
+            indices: D::first_indices(a.shape()),
             len,
             shape,
-            strides: a.strides.clone(),
+            strides: a.strides().clone(),
             axis,
-            sequence_dim: a.shape[axis],
+            sequence_dim: a.shape()[axis],
             phantom: PhantomData,
         }
     }

--- a/src/array/linarg.rs
+++ b/src/array/linarg.rs
@@ -1,8 +1,8 @@
 use core::ops::{AddAssign, Mul};
 
 use crate::{
-    storage::Storage, ArrayBase, Dimensionality, DimensionalityAfterDot, Dot, NDArray, NDArrayMut,
-    NDArrayOwned, Order, Shape,
+    array::iter::SequenceIter, storage::Storage, ArrayBase, Dimensionality, DimensionalityAfterDot,
+    Dot, NDArray, NDArrayMut, NDArrayOwned, Order, Shape,
 };
 
 macro_rules! impl_dot {
@@ -63,8 +63,10 @@ macro_rules! impl_dot {
 
                 let mut out = Self::Output::allocate_uninitialized(&out_shape);
                 let mut out_iter = out.iter_mut();
-                for in_iter in self.iter_sequence(in_n_dims - 1) {
-                    for rhs_iter in rhs.iter_sequence(match_axis) {
+                let in_iters = SequenceIter::new(self, in_n_dims - 1);
+                for in_iter in in_iters {
+                    let rhs_iters = SequenceIter::new(&rhs, match_axis);
+                    for rhs_iter in rhs_iters {
                         if let Some(out_elem) = out_iter.next() {
                             let mut it = in_iter.clone().zip(rhs_iter);
                             if let Some((in_elem, rhs_elem)) = it.next() {

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -1,7 +1,7 @@
 mod fmt;
 
 mod iter;
-pub use iter::{Iter, IterMut, SequenceIter};
+pub use iter::{Iter, IterMut};
 
 mod linarg;
 
@@ -144,11 +144,6 @@ macro_rules! impl_ndarray {
             #[inline]
             fn iter<'a>(&self) -> Self::Iter<'a> {
                 Iter::new(self)
-            }
-
-            #[inline]
-            fn iter_sequence<'a>(&self, axis: usize) -> SequenceIter<'a, <S as Storage>::Elem, D> {
-                SequenceIter::new(self, axis)
             }
 
             #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 extern crate alloc;
 
 mod array;
-pub use array::{Array, ArrayBase, Iter, IterMut, SequenceIter};
+pub use array::{Array, ArrayBase, Iter, IterMut};
 
 mod array_index;
 pub use array_index::{ArrayIndex, NewAxis};
@@ -90,10 +90,6 @@ pub trait NDArray {
         BD: Dimensionality;
     fn is_empty(&self) -> bool;
     fn iter<'a>(&self) -> Self::Iter<'a>;
-    fn iter_sequence<'a>(
-        &self,
-        axis: usize,
-    ) -> SequenceIter<'a, <Self::S as Storage>::Elem, Self::D>;
     fn len(&self) -> usize;
     fn ndims(&self) -> usize;
     fn permute(&self, axes: <Self::D as Dimensionality>::Shape) -> Result<Self::View<'_>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub trait NDArray {
         Self: 'a,
         D2: Dimensionality;
 
+    fn as_ptr(&self) -> *const <Self::S as Storage>::Elem;
     fn broadcast_to<BD>(
         &self,
         shape: &<BD as Dimensionality>::Shape,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,62 +60,83 @@ pub trait NDArray {
     type D: Dimensionality;
     type O: Order;
     type S: Storage;
+    type Iter<'a>: Iterator<Item = &'a <Self::S as Storage>::Elem>
+    where
+        <Self::S as Storage>::Elem: 'a;
+    type CowWithD<'a, D2>: NDArray<D = D2, O = Self::O, S = <Self::S as Storage>::Cow<'a>>
+    where
+        Self: 'a,
+        D2: Dimensionality;
+    type CowWithDO<'a, D2, O2>: NDArray<D = D2, O = O2, S = <Self::S as Storage>::Cow<'a>>
+    where
+        Self: 'a,
+        D2: Dimensionality,
+        O2: Order;
+    type Owned: NDArray<D = Self::D, O = Self::O, S = <Self::S as Storage>::Owned>;
+    type View<'a>: NDArray<D = Self::D, O = Self::O, S = <Self::S as Storage>::View<'a>>
+    where
+        Self: 'a;
+    type ViewWithD<'a, D2>: NDArray<D = D2, O = Self::O, S = <Self::S as Storage>::View<'a>>
+    where
+        Self: 'a,
+        D2: Dimensionality;
 
     fn broadcast_to<BD>(
         &self,
         shape: &<BD as Dimensionality>::Shape,
-    ) -> Result<ArrayBase<<Self::S as Storage>::View<'_>, BD, Self::O>>
+    ) -> Result<Self::ViewWithD<'_, BD>>
     where
         BD: Dimensionality;
     fn is_empty(&self) -> bool;
-    fn iter<'a>(&self) -> Iter<'a, <Self::S as Storage>::Elem, Self::D>;
+    fn iter<'a>(&self) -> Self::Iter<'a>;
     fn iter_sequence<'a>(
         &self,
         axis: usize,
     ) -> SequenceIter<'a, <Self::S as Storage>::Elem, Self::D>;
     fn len(&self) -> usize;
     fn ndims(&self) -> usize;
-    #[allow(clippy::type_complexity)]
-    fn permute(
-        &self,
-        axes: <Self::D as Dimensionality>::Shape,
-    ) -> Result<ArrayBase<<Self::S as Storage>::View<'_>, Self::D, Self::O>>;
+    fn permute(&self, axes: <Self::D as Dimensionality>::Shape) -> Result<Self::View<'_>>;
     fn shape(&self) -> &<Self::D as Dimensionality>::Shape;
     #[allow(clippy::type_complexity)]
     fn slice<ST, SD>(
         &self,
         info: SliceInfo<ST, SD>,
-    ) -> ArrayBase<
-        <Self::S as Storage>::View<'_>,
-        <Self::D as DimensionalityAdd<SD>>::Output,
-        Self::O,
-    >
+    ) -> Self::ViewWithD<'_, <Self::D as DimensionalityAdd<SD>>::Output>
     where
         Self::D: DimensionalityAdd<SD>,
         SD: DimensionalityDiff,
         ST: AsRef<[ArrayIndex]>;
     fn strides(&self) -> &<<Self::D as Dimensionality>::Shape as Shape>::Strides;
-    fn to_owned_array(&self) -> ArrayBase<<Self::S as Storage>::Owned, Self::D, Self::O>;
-    #[allow(clippy::type_complexity)]
+    fn to_owned_array(&self) -> Self::Owned;
     fn to_shape<NS>(
         &self,
         shape: NS,
-    ) -> Result<ArrayBase<<Self::S as Storage>::Cow<'_>, <NS as NewShape>::Dimensionality, Self::O>>
+    ) -> Result<Self::CowWithD<'_, <NS as NewShape>::Dimensionality>>
     where
         NS: NewShape;
     fn to_shape_with_order<NS, NO>(
         &self,
         shape: NS,
-    ) -> Result<ArrayBase<<Self::S as Storage>::Cow<'_>, <NS as NewShape>::Dimensionality, NO>>
+    ) -> Result<Self::CowWithDO<'_, <NS as NewShape>::Dimensionality, NO>>
     where
         NO: Order,
         NS: NewShape;
-    fn transpose(&self) -> ArrayBase<<Self::S as Storage>::View<'_>, Self::D, Self::O>;
-    fn view(&self) -> ArrayBase<<Self::S as Storage>::View<'_>, Self::D, Self::O>;
+    fn transpose(&self) -> Self::View<'_>;
+    fn view(&self) -> Self::View<'_>;
 }
 
-pub trait NDArrayMut: NDArray {
-    type SM: StorageMut;
+pub trait NDArrayMut: NDArray
+where
+    <Self as NDArray>::S: StorageMut,
+{
+    type ViewMutWithD<'a, D2>: NDArrayMut<
+        D = D2,
+        O = Self::O,
+        S = <Self::S as StorageMut>::ViewMut<'a>,
+    >
+    where
+        Self: 'a,
+        D2: Dimensionality;
 
     fn fill(&mut self, value: <Self::S as Storage>::Elem);
     fn iter_mut<'a>(&mut self) -> IterMut<'a, <Self::S as Storage>::Elem, Self::D>;
@@ -123,19 +144,20 @@ pub trait NDArrayMut: NDArray {
     fn slice_mut<ST, SD>(
         &mut self,
         info: SliceInfo<ST, SD>,
-    ) -> ArrayBase<
-        <Self::SM as StorageMut>::ViewMut<'_>,
-        <Self::D as DimensionalityAdd<SD>>::Output,
-        Self::O,
-    >
+    ) -> Self::ViewMutWithD<'_, <Self::D as DimensionalityAdd<SD>>::Output>
     where
         Self::D: DimensionalityAdd<SD>,
         SD: DimensionalityDiff,
         ST: AsRef<[ArrayIndex]>;
 }
 
-pub trait NDArrayOwned: NDArray {
-    type SO: StorageOwned;
+pub trait NDArrayOwned: NDArray
+where
+    <Self as NDArray>::S: StorageOwned,
+{
+    type WithD<D2>: NDArrayOwned<D = D2, O = Self::O, S = Self::S>
+    where
+        D2: Dimensionality;
 
     fn allocate_uninitialized<Sh>(shape: &Sh) -> Self
     where
@@ -146,16 +168,13 @@ pub trait NDArrayOwned: NDArray {
         T: NDArray,
         <<T as NDArray>::D as Dimensionality>::Shape: Shape<Dimensionality = Self::D>,
         <T as NDArray>::S: Storage<Elem = <Self::S as Storage>::Elem>;
-    fn into_shape<NS>(
-        self,
-        shape: NS,
-    ) -> Result<ArrayBase<Self::S, <NS as NewShape>::Dimensionality, Self::O>>
+    fn into_shape<NS>(self, shape: NS) -> Result<Self::WithD<<NS as NewShape>::Dimensionality>>
     where
         NS: NewShape;
     fn into_shape_with_order<NS, NO>(
         self,
         shape: NS,
-    ) -> Result<ArrayBase<Self::S, <NS as NewShape>::Dimensionality, NO>>
+    ) -> Result<Self::WithD<<NS as NewShape>::Dimensionality>>
     where
         NO: Order,
         NS: NewShape;


### PR DESCRIPTION
This change includes the followings:
- Remove specific types such as `ArrayBase` form traits such as `NDArray`
- Add the `as_ptr` method to `NDArray`
- Remove the `iter_sequence` method from `NDArray`